### PR TITLE
Simplify `setup-router` test helper.

### DIFF
--- a/tests/helpers/setup-router.js
+++ b/tests/helpers/setup-router.js
@@ -1,20 +1,5 @@
-import Ember from 'ember';
-
-export default function(AppRouter, { container, registry }) {
-  const RoutingService = Ember.__loader.require('ember-routing/services/routing').default;
-  const Route = Ember.__loader.require('ember-routing/system/route').default;
-  const namespace = { LOG_TRANSITIONS_INTERNAL: true, LOG_TRANSITIONS: true };
-
-  registry.register('application:main', namespace, { instantiate: false });
-  registry.register('router:main', AppRouter);
-  registry.injection('router:main', 'namespace', 'application:main');
-
-  registry.register('route:basic', Route);
-  registry.injection('route', 'router', 'router:main');
-
-  registry.register('service:-routing', RoutingService);
-  registry.injection('service:-routing', 'router', 'router:main');
-
+export default function({ container }) {
   const router = container.lookup('router:main');
-  router.startRouting(registry.resolver.moduleBasedResolver);
+
+  router.startRouting(true);
 }

--- a/tests/integration/components/nav-bar-test.js
+++ b/tests/integration/components/nav-bar-test.js
@@ -1,12 +1,11 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import AppRouter from 'cast/router';
 import setupRouter from '../../helpers/setup-router';
 
 moduleForComponent('nav-bar', 'Integration | Component | nav bar', {
   integration: true,
   setup() {
-    setupRouter(AppRouter, this);
+    setupRouter(this);
   }
 });
 


### PR DESCRIPTION
Much of the registraton, injection, etc is already done automatically by
`Ember.Application.buildRegistry` and is not needed to be duplicated
here.

When using ember-cli based resolver, `registry.resolver.moduleBasedResolver` will always be `true`, so I just passed `true` there instead...
